### PR TITLE
path detection failure fix (dirname: illegal option -- /)

### DIFF
--- a/etc/bashrc
+++ b/etc/bashrc
@@ -1,2 +1,2 @@
-abs_path=$(cd $(dirname $0)/.. && pwd)
+abs_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 export PATH=$abs_path/bin:$abs_path/apps:$PATH


### PR DESCRIPTION
I was getting:

> dirname: illegal option -- /
> usage: dirname path

full credit to: http://stackoverflow.com/a/246128/320438

Cheers,
Tim
